### PR TITLE
Wrapped AntPlusHeartRateSensor in a singleton so both the app and vie…

### DIFF
--- a/source/GenericAntPlusHeartRateFieldApp.mc
+++ b/source/GenericAntPlusHeartRateFieldApp.mc
@@ -20,5 +20,10 @@ class GenericAntPlusHeartRateFieldApp extends Application.AppBase {
     function getInitialView() {
         return [ new GenericAntPlusHeartRateFieldView() ];
     }
+    
+    // Triggered by settings change in GCM
+    function onSettingsChanged() { 
+	     HeartRateSensor.getInstance().open();
+	}
 
 }

--- a/source/GenericAntPlusHeartRateFieldApp.mc
+++ b/source/GenericAntPlusHeartRateFieldApp.mc
@@ -23,7 +23,7 @@ class GenericAntPlusHeartRateFieldApp extends Application.AppBase {
     
     // Triggered by settings change in GCM
     function onSettingsChanged() { 
-	     HeartRateSensor.getInstance().open();
+	     HeartRateSensor.getInstance().pair();
 	}
 
 }

--- a/source/GenericAntPlusHeartRateFieldView.mc
+++ b/source/GenericAntPlusHeartRateFieldView.mc
@@ -1,6 +1,4 @@
-using Toybox.Application;
 using Toybox.WatchUi;
-using GenericChannelHeartRateBarrel as HrBarrel;
 
 class GenericAntPlusHeartRateFieldView extends WatchUi.SimpleDataField {
 
@@ -14,11 +12,8 @@ class GenericAntPlusHeartRateFieldView extends WatchUi.SimpleDataField {
     
         mFitContributions = new FitContributions(self);
         
-        var deviceNumber = Application.getApp().getProperty("deviceNumber");
-        var proximityPairing = Application.getApp().getProperty("proximityPairing");
+        HeartRateSensor.getInstance().open();
 
-        mHrChannel = new HrBarrel.AntPlusHeartRateSensor(deviceNumber, proximityPairing);
-        mHrChannel.open();
     }
 
     // The given info object contains all the current workout
@@ -27,7 +22,7 @@ class GenericAntPlusHeartRateFieldView extends WatchUi.SimpleDataField {
     // guarantee that compute() will be called before onUpdate().
     function compute(info) {
         // See Activity.Info in the documentation for available information.
-        var heartRate = mHrChannel.data.computedHeartRate;
+        var heartRate = HeartRateSensor.getInstance().getHeartRate();
         mFitContributions.setHeartRateData(heartRate);
         return heartRate > 0 ? heartRate : "--";
     }

--- a/source/GenericAntPlusHeartRateFieldView.mc
+++ b/source/GenericAntPlusHeartRateFieldView.mc
@@ -12,7 +12,7 @@ class GenericAntPlusHeartRateFieldView extends WatchUi.SimpleDataField {
     
         mFitContributions = new FitContributions(self);
         
-        HeartRateSensor.getInstance().open();
+        HeartRateSensor.getInstance().pair();
 
     }
 

--- a/source/HeartRateSensor.mc
+++ b/source/HeartRateSensor.mc
@@ -1,0 +1,37 @@
+using Toybox.Application;
+using GenericChannelHeartRateBarrel as HrBarrel;
+
+class HeartRateSensor {
+
+	hidden var mHrChannel = null;
+    
+    hidden static var instance = null;
+    static function getInstance() {
+        if(instance == null) {
+            instance = new HeartRateSensor();
+        }
+        return instance;
+	}
+	
+	private function initialize() {
+        open();
+	}
+	
+	function open() {
+	
+		if(mHrChannel != null) {
+			mHrChannel.release();
+			mHrChannel = null;
+		}
+	
+        var deviceNumber = Application.getApp().getProperty("deviceNumber");
+        var proximityPairing = Application.getApp().getProperty("proximityPairing");
+
+        mHrChannel = new HrBarrel.AntPlusHeartRateSensor(deviceNumber, proximityPairing);
+        mHrChannel.open();
+	}
+	
+	function getHeartRate() {
+        return mHrChannel.data.computedHeartRate;
+    }
+}

--- a/source/HeartRateSensor.mc
+++ b/source/HeartRateSensor.mc
@@ -14,10 +14,9 @@ class HeartRateSensor {
 	}
 	
 	private function initialize() {
-        open();
 	}
 	
-	function open() {
+	function pair() {
 	
 		if(mHrChannel != null) {
 			mHrChannel.release();


### PR DESCRIPTION
Wrapped AntPlusHeartRateSensor in a singleton so both the app and view can access it without creating an unnecessary dependency between the two. This was done so that the app can react to Settings Changed events and a channel can be opened using a new device index.

@harrychin This is my first pass, which works, and I am open to changing the names of things. Does "open" work for you? It hides a call to release() which is good and bad.